### PR TITLE
Fix order of timestamps in DateRestriction

### DIFF
--- a/docs/discussions.rst
+++ b/docs/discussions.rst
@@ -70,10 +70,10 @@ The legacy caveat are represented by classes prefixed by ``Legacy``.
 
 The types of caveats are:
 
-- ``[0, <timestamp: int>, <timestamp: int>]`` is met if we try uploading the
-  project between ``nbf`` (included) and ``exp`` (excluded). It's represented
-  by the class `DateRestriction`. Legacy format is ``"{"nbf": <timestamp: int>,
-  "exp": <timestamp: int>}"`` and the corresponding class is
+- ``[0, <exp: int>, <nbf: int>]`` is met if we try uploading the project
+  between timestamps ``nbf`` (included) and ``exp`` (excluded). It's
+  represented by the class `DateRestriction`. Legacy format is ``"{"nbf":
+  <timestamp: int>, "exp": <timestamp: int>}"`` and the corresponding class is
   `LegacyDateRestriction`.
 
 - ``[1, [<project_name: str>, ...]]`` is met if the project we upload is among

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -87,11 +87,11 @@ without a token. In this case, you can use the methods on the `Restriction` clas
 
     import pypitoken
     restriction = pypitoken.Restriction.load_json(
-        '[0, 1234567890, 1234567891]'
+        '[0, 1234567891, 1234567890]'
     )
     # or
     restriction = pypitoken.Restriction.load(
-        [0, 1234567890, 1234567891]
+        [0, 1234567891, 1234567890]
     )
     # DateRestriction()
 

--- a/pypitoken/restrictions.py
+++ b/pypitoken/restrictions.py
@@ -273,12 +273,12 @@ class DateRestriction(Restriction):
     @classmethod
     def _extract_kwargs(cls, value: list) -> dict:
         return {
-            "not_before": value[1],
-            "not_after": value[2],
+            "not_before": value[2],  # Yes, the official order is "reversed"
+            "not_after": value[1],
         }
 
     def dump(self) -> list:
-        return [self.tag, self.not_before, self.not_after]
+        return [self.tag, self.not_after, self.not_before]
 
     def check(self, context: Context) -> None:
         super().check(context=context)

--- a/tests/test_restrictions.py
+++ b/tests/test_restrictions.py
@@ -367,7 +367,7 @@ def test__Restriction__restrictions_from_parameters():
 
 def test__DateRestriction__load_value__pass():
     assert restrictions.DateRestriction._load_value(
-        value=[0, 1_234_567_890, 1_234_567_900]
+        value=[0, 1_234_567_900, 1_234_567_890]
     ) == restrictions.DateRestriction(not_before=1_234_567_890, not_after=1_234_567_900)
 
 
@@ -375,12 +375,12 @@ def test__DateRestriction__load_value__pass():
     "value",
     [
         [],
-        [1, 1_234_567_890, 1_234_567_900],
+        [1, 1_234_567_900, 1_234_567_890],
         [0],
         [0, 1_234_567_890],
-        [0, 1_234_567_890, 1_234_567_900, 1_234_567_999],
-        [0, "1_234_567_890", "1_234_567_900"],
-        [0, "2000-01-01 00:00:00", "2000-01-02 00:00:00"],
+        [0, 1_234_567_890, 1_234_567_999, 1_234_567_900],
+        [0, "1_234_567_900", "1_234_567_890"],
+        [0, "2000-01-02 00:00:00", "2000-01-01 00:00:00"],
     ],
 )
 def test__DateRestriction__load_value__fail(value):
@@ -389,7 +389,7 @@ def test__DateRestriction__load_value__fail(value):
 
 
 def test__DateRestriction__extract_kwargs():
-    value = [0, 1_234_567_890, 1_234_567_900]
+    value = [0, 1_234_567_900, 1_234_567_890]
     kwargs = restrictions.DateRestriction._extract_kwargs(value=value)
     assert kwargs == {"not_before": 1_234_567_890, "not_after": 1_234_567_900}
 
@@ -420,7 +420,7 @@ def test__DateRestriction__dump():
     restriction = restrictions.DateRestriction(
         not_before=1_234_567_890, not_after=1_234_567_900
     )
-    assert restriction.dump() == [0, 1_234_567_890, 1_234_567_900]
+    assert restriction.dump() == [0, 1_234_567_900, 1_234_567_890]
 
 
 def test__DateRestriction__from_parameters__empty():


### PR DESCRIPTION
Closes #157 

Mismatch in the caveat format for date restrictions between pypi and this lib.

### Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)

<!-- We hope your contributing experience was great so far. If you would like to
provide some feedback, please feel free to do so! -->
