### PR TITLE
Pin CI to the committed lockfile

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,6 +1,9 @@
 name: autofix.ci
 on: [pull_request]
 
+env:
+  UV_FROZEN: "true"
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     tags:
       - '*'
 
+env:
+  UV_FROZEN: "true"
+
 permissions:
   contents: read
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
 
       - id: uv-lock
         name: uv-lock
-        entry: uv lock
+        entry: env UV_FROZEN=false uv lock
         language: system
         files: ^(uv\.lock|pyproject\.toml|uv\.toml)$
         pass_filenames: false


### PR DESCRIPTION
CI runs `uv run` / `uv sync` with no guard today, so when `pyproject.toml` and `uv.lock` disagree, uv quietly re-resolves, rewrites `uv.lock` inside the runner and tests a dependency set that was never committed. The job goes green, the rewritten lock is thrown away, and the same commit can resolve differently on a later rerun.

`UV_FROZEN: "true"` on every uv-using workflow makes CI use the committed lock and nothing else.

On its own that would hide the drift rather than fix it — under `UV_FROZEN`, `uv lock` degrades to an existence check and exits 0. So the `uv-lock` hook overrides it with `entry: env UV_FROZEN=false uv lock`. Drift then surfaces in exactly one place: the hook fails with "files were modified by this hook", and autofix.ci commits the corrected lock back. Every other `uv` call stays quiet.

`UV_LOCKED` was the alternative. It would scatter "lockfile needs to be updated" across every test job, and stop autofix from repairing the lock at all, since uv would refuse to write.

### Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

<!-- We hope your contributing experience was great so far. If you would like to
provide some feedback, please feel free to do so! -->